### PR TITLE
Obtains latest raspbian from raspberrypi.org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch
 
 RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y apt-utils \
@@ -35,16 +35,19 @@ ENV ARCH=arm \
     SYSROOT=$RPXC_ROOT/sysroot
 
 WORKDIR $SYSROOT
-RUN curl -Ls https://github.com/sdhibit/docker-rpi-raspbian/raw/master/raspbian.2015.05.05.tar.xz \
-    | tar -xJf - \
- && curl -Ls https://github.com/resin-io-projects/armv7hf-debian-qemu/raw/master/bin/qemu-arm-static \
-    > $SYSROOT/$QEMU_PATH \
- && chmod +x $SYSROOT/$QEMU_PATH \
- && mkdir -p $SYSROOT/build \
- && chroot $SYSROOT $QEMU_PATH /bin/sh -c '\
-        echo "deb http://archive.raspbian.org/raspbian jessie firmware" \
+RUN curl -Ls https://downloads.raspberrypi.org/raspbian_lite/root.tar.xz \
+| tar -xJf -
+ADD https://github.com/resin-io-projects/armv7hf-debian-qemu/raw/master/bin/qemu-arm-static $SYSROOT/$QEMU_PATH
+
+RUN chmod +x $SYSROOT/$QEMU_PATH \
+ && mkdir -p $SYSROOT/build
+
+RUN chroot $SYSROOT $QEMU_PATH /bin/sh -c '\
+        echo "deb http://archive.raspbian.org/raspbian stretch firmware" \
             >> /etc/apt/sources.list \
         && apt-get update \
+        && sudo apt-mark hold \
+     raspberrypi-bootloader raspberrypi-kernel raspberrypi-sys-mods raspi-config \
         && DEBIAN_FRONTEND=noninteractive apt-get install -y apt-utils \
         && DEBIAN_FRONTEND=noninteractive dpkg-reconfigure apt-utils \
         && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
@@ -57,3 +60,5 @@ COPY image/ /
 
 WORKDIR /build
 ENTRYPOINT [ "/rpxc/entrypoint.sh" ]
+
+RUN install-debian libc6-armhf-cross


### PR DESCRIPTION
I modified the Dockerfile to pull the latest rootfs of Raspbian Lite from the Raspberry Pi website. That removes the need to commit new versions of the script for each release of Raspbian. However, it also results in a much larger image that before.