### PR TITLE
Added libraspberrypi-dev to xbuild env.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN curl -Ls https://github.com/sdhibit/docker-rpi-raspbian/raw/master/raspbian.
         && DEBIAN_FRONTEND=noninteractive apt-get install -y \
                 libc6-dev \
                 symlinks \
+                libraspberrypi-dev \
         && symlinks -cors /'
 
 COPY image/ /


### PR DESCRIPTION
I needed to build [raspiraw](https://github.com/6by9/raspiraw).

I found out that adding `libraspberrypi-dev` as in this pull request everything goes smoothly.
Since this docker image is intended as a cross compilation tool for Raspberry PIs, I think that it would be convenient including `libraspberrypi-dev` by default...
